### PR TITLE
Debug backend render deployment error

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -138,8 +138,9 @@ if (process.env.NODE_ENV === 'production') {
   // Serve static files from Vite build (dist folder)
   app.use(express.static(path.join(__dirname, '../frontend/dist')));
   
-  // Handle React Router - send all non-API requests to React
-  app.get('*', (req, res) => {
+  // Serve SPA index.html for all non-API routes without using path patterns
+  app.use((req, res, next) => {
+    if (req.path.startsWith('/api')) return next();
     res.sendFile(path.join(__dirname, '../frontend/dist/index.html'));
   });
 } else {


### PR DESCRIPTION
Replace Express 5 incompatible `app.get('*', ...)` catch-all with a middleware fallback to fix `path-to-regexp` error.

The `path-to-regexp` library, used by Express 5, no longer supports the `*` wildcard directly in `app.get()`. This change updates the production static file serving logic to use `app.use()` middleware, which correctly serves the SPA's `index.html` for non-API routes, resolving the `TypeError`.

---
<a href="https://cursor.com/background-agent?bcId=bc-45c6a1b3-0fd3-4fb1-b25f-1bb0ac94ddd8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-45c6a1b3-0fd3-4fb1-b25f-1bb0ac94ddd8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

